### PR TITLE
Feature/support date and time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+ * Correctly output Date, Time, and Timestamp - use SQL to work-around TDS limitations
+ * Working option to emit Dates as Dates without Timestamp: "use_date_datatype": true
+ 
 ## 1.0.2
  * Cleaning up imports
  * Supporting Sybase ASA / IQ data dictionary as well as ASE.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-sybase",
-    version="1.0.2",
+    version="1.0.3",
     description="Singer.io tap for extracting data from SQL Server - PipelineWise compatible",
     author="Stitch",
     url="https://github.com/s7clarke10/tap-sybase",

--- a/tap_sybase/__init__.py
+++ b/tap_sybase/__init__.py
@@ -150,8 +150,13 @@ def schema_for_column(c, config):
         result.format = "date-time"
 
     elif data_type in DATE_TYPES:
-        result.type = ["null", "string"]
-        result.format = "date"
+        if use_date_data_type_format:
+            result.type = ["null", "string"]
+            result.format = "date"
+        else:
+            result.type = ["null", "string"]
+            result.format = "date-time"
+            result.additionalProperties = {"sql_data_type": "date"}
 
     elif data_type in TIME_TYPES:
         result.type = ["null", "string"]

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -97,7 +97,7 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
                       substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
                     ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'
-                    else {column_name} end
+                    else null end
                     """
         else:
             # return "replace(convert(Char, {} , 140),' ','T')||'+00:00'".format(column_name)
@@ -107,7 +107,7 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
                     ||substring(convert(Char, {column_name}, 102),9,2)||'T'
                     ||substring(convert(Char, {column_name} , 108),1,2)
                     ||substring(convert(Char, {column_name}, 109),15,10)||'Z'
-                    else {column_name} end
+                    else null end
                     """
     elif 'string' in schema_property.type and schema_property.format == 'date':
         if use_date_data_type_format:
@@ -118,7 +118,7 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
                       substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
                     ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'
-                    else {column_name} end
+                    else null end
                     """
     return column_name
 
@@ -130,6 +130,8 @@ def generate_select_sql(catalog_entry, columns, config):
     escaped_columns = map(lambda c: prepare_columns_sql(catalog_entry, c, use_date_data_type_format), columns)
 
     select_sql = "SELECT {} FROM {}.{}".format(",".join(escaped_columns), escaped_db, escaped_table)
+
+    # print(f"The SQL = {select_sql}")
 
     # escape percent signs
     select_sql = select_sql.replace("%", "%%")

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -117,7 +117,6 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
         return "convert(char, {} , 140)".format(column_name)
     elif 'string' in schema_property.type and schema_property.format == 'date-time':
         if sql_data_type == 'date' and not use_date_data_type_format:
-            # return "replace(convert(Char, {} , 140),' ','T')||'T00:00:00+00:00'".format(column_name)
             return f"""case when {column_name} is not null then
                       substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
@@ -125,7 +124,6 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
                     else null end
                     """
         else:
-            # return "replace(convert(Char, {} , 140),' ','T')||'+00:00'".format(column_name)
             return f"""case when {column_name} is not null then
                      substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
@@ -139,7 +137,6 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
         if use_date_data_type_format:
             return "convert(char, {} , 140)".format(column_name)
         else:
-            # return "convert(char, {} , 140)||'T00:00:00+00:00'".format(column_name)
             return f"""case when {column_name} is not null then
                       substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
@@ -156,8 +153,6 @@ def generate_select_sql(catalog_entry, columns, config):
     escaped_columns = map(lambda c: prepare_columns_sql(catalog_entry, c, use_date_data_type_format), columns)
 
     select_sql = "SELECT {} FROM {}.{}".format(",".join(escaped_columns), escaped_db, escaped_table)
-
-    # print(f"The SQL = {select_sql}")
 
     # escape percent signs
     select_sql = select_sql.replace("%", "%%")

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -105,8 +105,9 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
                      substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
                     ||substring(convert(Char, {column_name}, 102),9,2)||'T'
-                    ||substring(convert(Char, {column_name} , 108),1,2)
-                    ||substring(convert(Char, {column_name}, 109),15,10)||'+00:00'
+                    ||substring(convert(Char, {column_name}, 108),1,2)
+                    ||substring(convert(Char, {column_name}, 109),15,6)||'.'
+                    ||substring(convert(Char, {column_name}, 109),22,3)||'+00:00'
                     else null end
                     """
     elif 'string' in schema_property.type and schema_property.format == 'date':

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -92,14 +92,25 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
         return "convert(char, {} , 140)".format(column_name)
     elif 'string' in schema_property.type and schema_property.format == 'date-time':
         if sql_data_type == 'date' and not use_date_data_type_format:
-            return "replace(convert(Char, {} , 140),' ','T')||'T00:00:00+00:00'".format(column_name)
+            # return "replace(convert(Char, {} , 140),' ','T')||'T00:00:00+00:00'".format(column_name)
+            return f"""substring(convert(Char, {column_name}, 102),1,4)||'-'
+                    ||substring(convert(Char, {column_name}, 102),6,2)||'-'
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'"""
         else:
-            return "replace(convert(Char, {} , 140),' ','T')||'+00:00'".format(column_name)
+            # return "replace(convert(Char, {} , 140),' ','T')||'+00:00'".format(column_name)
+            return f"""substring(convert(Char, {column_name}, 102),1,4)||'-'
+                    ||substring(convert(Char, {column_name}, 102),6,2)||'-'
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T'
+                    ||substring(convert(Char, {column_name} , 108),1,2)
+                    ||substring(convert(Char, {column_name}, 109),15,10)||'Z'"""
     elif 'string' in schema_property.type and schema_property.format == 'date':
         if use_date_data_type_format:
             return "convert(char, {} , 140)".format(column_name)
         else:
-            return "convert(char, {} , 140)||'T00:00:00+00:00'".format(column_name)
+            # return "convert(char, {} , 140)||'T00:00:00+00:00'".format(column_name)
+            return f"""substring(convert(Char, {column_name}, 102),1,4)||'-'
+                    ||substring(convert(Char, {column_name}, 102),6,2)||'-'
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'"""
     return column_name
 
 def generate_select_sql(catalog_entry, columns, config):

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -96,7 +96,7 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
             return f"""case when {column_name} is not null then
                       substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
-                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00+00:00'
                     else null end
                     """
         else:
@@ -106,7 +106,7 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
                     ||substring(convert(Char, {column_name}, 102),9,2)||'T'
                     ||substring(convert(Char, {column_name} , 108),1,2)
-                    ||substring(convert(Char, {column_name}, 109),15,10)||'Z'
+                    ||substring(convert(Char, {column_name}, 109),15,10)||'+00:00'
                     else null end
                     """
     elif 'string' in schema_property.type and schema_property.format == 'date':
@@ -117,7 +117,7 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
             return f"""case when {column_name} is not null then
                       substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
-                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00+00:00'
                     else null end
                     """
     return column_name

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -93,24 +93,33 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
     elif 'string' in schema_property.type and schema_property.format == 'date-time':
         if sql_data_type == 'date' and not use_date_data_type_format:
             # return "replace(convert(Char, {} , 140),' ','T')||'T00:00:00+00:00'".format(column_name)
-            return f"""substring(convert(Char, {column_name}, 102),1,4)||'-'
+            return f"""case when {column_name} is not null then
+                      substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
-                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'"""
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'
+                    else {column_name} end
+                    """
         else:
             # return "replace(convert(Char, {} , 140),' ','T')||'+00:00'".format(column_name)
-            return f"""substring(convert(Char, {column_name}, 102),1,4)||'-'
+            return f"""case when {column_name} is not null then
+                     substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
                     ||substring(convert(Char, {column_name}, 102),9,2)||'T'
                     ||substring(convert(Char, {column_name} , 108),1,2)
-                    ||substring(convert(Char, {column_name}, 109),15,10)||'Z'"""
+                    ||substring(convert(Char, {column_name}, 109),15,10)||'Z'
+                    else {column_name} end
+                    """
     elif 'string' in schema_property.type and schema_property.format == 'date':
         if use_date_data_type_format:
             return "convert(char, {} , 140)".format(column_name)
         else:
             # return "convert(char, {} , 140)||'T00:00:00+00:00'".format(column_name)
-            return f"""substring(convert(Char, {column_name}, 102),1,4)||'-'
+            return f"""case when {column_name} is not null then
+                      substring(convert(Char, {column_name}, 102),1,4)||'-'
                     ||substring(convert(Char, {column_name}, 102),6,2)||'-'
-                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'"""
+                    ||substring(convert(Char, {column_name}, 102),9,2)||'T00:00:00Z'
+                    else {column_name} end
+                    """
     return column_name
 
 def generate_select_sql(catalog_entry, columns, config):

--- a/tap_sybase/sync_strategies/full_table.py
+++ b/tap_sybase/sync_strategies/full_table.py
@@ -55,12 +55,12 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
 
     with connect_with_backoff(mssql_conn) as open_conn:
         with open_conn.cursor() as cur:
-            select_sql = common.generate_select_sql(catalog_entry, columns)
+            select_sql = common.generate_select_sql(catalog_entry, columns, config)
 
             params = {}
 
             common.sync_query(
-                cur, catalog_entry, state, select_sql, columns, stream_version, params, config
+                cur, catalog_entry, state, select_sql, columns, stream_version, params
             )
 
     # clear max pk value and last pk fetched upon successful sync

--- a/tap_sybase/sync_strategies/incremental.py
+++ b/tap_sybase/sync_strategies/incremental.py
@@ -48,7 +48,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
     LOGGER.info("Beginning SQL")
     with connect_with_backoff(mssql_conn) as open_conn:
         with open_conn.cursor() as cur:
-            select_sql = common.generate_select_sql(catalog_entry, columns)
+            select_sql = common.generate_select_sql(catalog_entry, columns, config)
             params = {}
 
             if replication_key_value is not None:
@@ -64,5 +64,5 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
                 select_sql += " ORDER BY \"{}\" ASC".format(replication_key_metadata)
 
             common.sync_query(
-                cur, catalog_entry, state, select_sql, columns, stream_version, params, config
+                cur, catalog_entry, state, select_sql, columns, stream_version, params
             )

--- a/tap_sybase/sync_strategies/log_based.py
+++ b/tap_sybase/sync_strategies/log_based.py
@@ -146,7 +146,7 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
     with connect_with_backoff(mssql_conn) as open_conn:
         with open_conn.cursor() as cur:
 
-            escaped_columns = [common.escape(c) for c in columns]
+            escaped_columns = map(lambda c: common.prepare_columns_sql(catalog_entry, c, config), columns)
             table_name      = catalog_entry.table
             schema_name     = common.get_database_name(catalog_entry)
 
@@ -173,7 +173,7 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
             params = {}
 
             common.sync_query(
-                cur, catalog_entry, state, select_sql, extended_columns, stream_version, params, config
+                cur, catalog_entry, state, select_sql, extended_columns, stream_version, params
             )
             state = singer.write_bookmark(state, catalog_entry.tap_stream_id, 'lsn', lsn_to)
 
@@ -262,7 +262,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
                 params = {}
 
                 common.sync_query(
-                    cur, catalog_entry, state, select_sql, extended_columns, stream_version, params, config
+                    cur, catalog_entry, state, select_sql, extended_columns, stream_version, params
                 )
 
             else:


### PR DESCRIPTION
This PR changes the way dates, times, and timestamps/datetimes are discovered in Sybase ASA, and Sybase ASE.

The underlying Sybase Driver via pymssql and freetds only supports the legacy datetime datatype only. More modern versions using timestamp, date, and time come through as binary code.

The change is for Sybase to detect the datatype and then convert the data in the database via a SQL convert statement to a string to be emitted by singer. 

The traditional SQL formats are limited on older versions of Sybase so a rather esoteric SQL statement has been used to get the best precision available allowing the tap to run on Sybase ASA and ASE with much older versions. 