### PR TITLE
Feature/support cursor fetch many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+ * Including support for fetchmany records. This will improve extract speed in low latency networks.
+ * Adjust the size via the cursor_array_size parameter, the default is 1. Changing to 10,000 will improve performance
+
 ## 1.0.3
  * Correctly output Date, Time, and Timestamp - use SQL to work-around TDS limitations
  * Working option to emit Dates as Dates without Timestamp: "use_date_datatype": true

--- a/README.md
+++ b/README.md
@@ -110,8 +110,17 @@ The characterset for the database / source system. The default is `utf8`, howeve
 }
 ```
 
+Optional:
+To make use of fetchmany(x) instead of fetchone(), use cursor_array_size with an integer value indicating the number of rows to pull. This can help in some architectures by pulling more rows into memory. The default if omitted is 1, the tap will still use fetchmany, but with an argument of 1, under the assumption that fetchmany(1) === fetchone().
+Usage:
+```json
+{
+  "cursor_array_size": 10000
+}
+```
+
 These are the same basic configuration properties used by the sybase command-line
-client (`sybase`).
+client (`tap-sybase`).
 
 ### Discovery mode
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-sybase",
-    version="1.0.3",
+    version="1.0.4",
     description="Singer.io tap for extracting data from SQL Server - PipelineWise compatible",
     author="Stitch",
     url="https://github.com/s7clarke10/tap-sybase",

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -230,9 +230,7 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
     time_extracted = utils.now()
     cursor.execute(select_sql, params)
 
-    # row = cursor.fetchone()
     LOGGER.info(f"{arraysize=}")
-    # rows = cursor.fetchmany(size=batch_size)
     rows_saved = 0
 
     database_name = get_database_name(catalog_entry)
@@ -241,7 +239,6 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
         counter.tags["database"] = database_name
         counter.tags["table"] = catalog_entry.table
 
-        # while row:
         for row in ResultIter(cursor,arraysize):
             counter.increment()
             rows_saved += 1
@@ -300,6 +297,5 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
             if rows_saved % 1000 == 0:
                 singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
-            # row = cursor.fetchone()
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -212,16 +212,27 @@ def whitelist_bookmark_keys(bookmark_key_set, tap_stream_id, state):
     ]:
         singer.clear_bookmark(state, tap_stream_id, bk)
 
+def ResultIter(cursor, arraysize):
+    'An iterator that uses fetchmany to keep memory usage down'
+    while True:
+        results = cursor.fetchmany(arraysize)
+        if not results:
+            break
+        for result in results:
+            yield result
 
-def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version, params):
+def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version, params, config):
     replication_key = singer.get_bookmark(state, catalog_entry.tap_stream_id, "replication_key")
 
+    arraysize = int(config.get("cursor_array_size", "1"))
     select_sql = select_sql.replace('"', '')
 
     time_extracted = utils.now()
     cursor.execute(select_sql, params)
 
-    row = cursor.fetchone()
+    # row = cursor.fetchone()
+    LOGGER.info(f"{arraysize=}")
+    # rows = cursor.fetchmany(size=batch_size)
     rows_saved = 0
 
     database_name = get_database_name(catalog_entry)
@@ -230,7 +241,8 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
         counter.tags["database"] = database_name
         counter.tags["table"] = catalog_entry.table
 
-        while row:
+        # while row:
+        for row in ResultIter(cursor,arraysize):
             counter.increment()
             rows_saved += 1
             record_message = row_to_singer_record(
@@ -288,6 +300,6 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
             if rows_saved % 1000 == 0:
                 singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
-            row = cursor.fetchone()
+            # row = cursor.fetchone()
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_sybase/sync_strategies/full_table.py
+++ b/tap_sybase/sync_strategies/full_table.py
@@ -60,7 +60,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
             params = {}
 
             common.sync_query(
-                cur, catalog_entry, state, select_sql, columns, stream_version, params
+                cur, catalog_entry, state, select_sql, columns, stream_version, params, config
             )
 
     # clear max pk value and last pk fetched upon successful sync

--- a/tap_sybase/sync_strategies/incremental.py
+++ b/tap_sybase/sync_strategies/incremental.py
@@ -64,5 +64,5 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
                 select_sql += " ORDER BY \"{}\" ASC".format(replication_key_metadata)
 
             common.sync_query(
-                cur, catalog_entry, state, select_sql, columns, stream_version, params
+                cur, catalog_entry, state, select_sql, columns, stream_version, params, config
             )

--- a/tap_sybase/sync_strategies/log_based.py
+++ b/tap_sybase/sync_strategies/log_based.py
@@ -173,7 +173,7 @@ def sync_historic_table(mssql_conn, config, catalog_entry, state, columns, strea
             params = {}
 
             common.sync_query(
-                cur, catalog_entry, state, select_sql, extended_columns, stream_version, params
+                cur, catalog_entry, state, select_sql, extended_columns, stream_version, params, config
             )
             state = singer.write_bookmark(state, catalog_entry.tap_stream_id, 'lsn', lsn_to)
 
@@ -262,7 +262,7 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns, stream_version
                 params = {}
 
                 common.sync_query(
-                    cur, catalog_entry, state, select_sql, extended_columns, stream_version, params
+                    cur, catalog_entry, state, select_sql, extended_columns, stream_version, params, config
                 )
 
             else:


### PR DESCRIPTION
This feature introduces a new parameter cursor_array_size.

By default it is set to a value of 1. By increase the size it will fetch more than one record improving performance in low latency networks by reducing the number of round trips to the database.

Increasing to a size of 10,000 is recommend to get a boost in performance for large tables. Be careful to not set too high as it will require additional memory.