### PR TITLE
Feature/fix currently syncing rerun bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.7
+ * Handling currently_syncing streams with no bookmarks, this scenario was stopping the stream from syncing.
+
 ## 1.0.6
  * Handling NULL's / None in Singer.Decimal columns.
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-sybase",
-    version="1.0.6",
+    version="1.0.7",
     description="Singer.io tap for extracting data from SQL Server - PipelineWise compatible",
     author="Stitch",
     url="https://github.com/s7clarke10/tap-sybase",

--- a/tap_sybase/__init__.py
+++ b/tap_sybase/__init__.py
@@ -504,10 +504,9 @@ def get_non_cdc_streams(mssql_conn, catalog, config, state):
 
     for stream in selected_streams:
         stream_metadata = metadata.to_map(stream.metadata)
-        # if stream_metadata.table in ["aagaggpercols", "aagaggdef"]:
+
         for k, v in stream_metadata.get((), {}).items():
             LOGGER.info(f"{k}: {v}")
-            # LOGGER.info(stream_metadata.get((), {}).get("table-key-properties"))
         replication_method = stream_metadata.get((), {}).get("replication-method")
         stream_state = state.get("bookmarks", {}).get(stream.tap_stream_id)
 
@@ -541,7 +540,7 @@ def get_non_cdc_streams(mssql_conn, catalog, config, state):
             filter(
                 lambda s: s.tap_stream_id == currently_syncing
                 and is_valid_currently_syncing_stream(s, state),
-                streams_with_state,
+                ordered_streams,
             )
         )
 


### PR DESCRIPTION
We have encountered a scenario where a stream starts but it failed and there was no bookmark written.

When the job is re-run the state file had currently_syncing for the given stream but with no bookmark written it didn't appear in the streams_with_state list. This small change will ensure that the currently_syncing_list will be populated whether there is a bookmark or not by filtering against the ordered_streams list which includes both streams_without_state and streams_with_state.

Example:

state.json looks like the example below. In this scenario the "YELLOW_BANANAS" stream would not sync with the previous code because it is Currently Syncing with no bookmark / state.

{"currently_syncing": "YELLOW_BANANAS"}