### PR TITLE
Update output for float types

### DIFF
--- a/tap_sybase/__init__.py
+++ b/tap_sybase/__init__.py
@@ -124,7 +124,6 @@ def schema_for_column(c, config):
         if use_singer_decimal:
             result.type = ["null","string"]
             result.format = "singer.decimal"
-            result.additionalProperties = {"scale_precision": f"({c.numeric_precision},{c.numeric_scale})"}
         else:
             result.type = ["null", "number"]
             result.multipleOf = 10 ** (0 - (c.numeric_scale or 17))
@@ -133,7 +132,7 @@ def schema_for_column(c, config):
         if use_singer_decimal:
             result.type = ["null","number"]
             result.format = "singer.decimal"
-            result.additionalProperties = {"scale_precision": f"({c.numeric_precision},{c.numeric_scale})"}
+            result.additionalProperties = {"scale_precision": f"({c.numeric_precision},{c.numeric_scale or 0})"}
         else:
             result.type = ["null", "number"]
             result.multipleOf = 10 ** (0 - c.numeric_scale)

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -110,8 +110,10 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
     column_name = """ "{}" """.format(c)
     schema_property = catalog_entry.schema.properties[c]
     sql_data_type = ""
+    # additionalProperties is used with singer.decimal to contain scale/precision
+    # in those cases, there will not be an sql_data_type value in the schema
     if schema_property.additionalProperties:
-        sql_data_type = schema_property.additionalProperties['sql_data_type']
+        sql_data_type = schema_property.additionalProperties.get('sql_data_type',"")
 
     if 'string' in schema_property.type and schema_property.format == 'time':
         return "convert(char, {} , 140)".format(column_name)


### PR DESCRIPTION
Float types no longer store scale/precision as this can be misleading for floats and should not be passed on to targets