### PR TITLE
Updates for float types and removal of reversion to FULL_TABLE when INCREMENTAL and no PK set

### DIFF
--- a/tap_sybase/__init__.py
+++ b/tap_sybase/__init__.py
@@ -124,7 +124,6 @@ def schema_for_column(c, config):
         if use_singer_decimal:
             result.type = ["null","string"]
             result.format = "singer.decimal"
-            result.additionalProperties = {"scale_precision": f"({c.numeric_precision},{c.numeric_scale})"}
         else:
             result.type = ["null", "number"]
             result.multipleOf = 10 ** (0 - (c.numeric_scale or 17))
@@ -133,7 +132,7 @@ def schema_for_column(c, config):
         if use_singer_decimal:
             result.type = ["null","number"]
             result.format = "singer.decimal"
-            result.additionalProperties = {"scale_precision": f"({c.numeric_precision},{c.numeric_scale})"}
+            result.additionalProperties = {"scale_precision": f"({c.numeric_precision},{c.numeric_scale or 0})"}
         else:
             result.type = ["null", "number"]
             result.multipleOf = 10 ** (0 - c.numeric_scale)

--- a/tap_sybase/__init__.py
+++ b/tap_sybase/__init__.py
@@ -685,9 +685,8 @@ def sync_non_cdc_streams(mssql_conn, non_cdc_catalog, config, state):
                 f"No replication key for {catalog_entry.table}, using full table replication"
             )
             replication_method = "FULL_TABLE"
-        if replication_method == "INCREMENTAL" and not primary_keys:
-            LOGGER.info(f"No primary key for {catalog_entry.table}, using full table replication")
-            replication_method = "FULL_TABLE"
+        # Check for INCREMENTAL load without primary keys removed
+        # INCREMENTAL loads can be performed without primary keys as long as there is a replication key
         if replication_method == "LOG_BASED" and not start_lsn:
             LOGGER.info(
                 f"No initial load for {catalog_entry.table}, using full table replication"

--- a/tap_sybase/sync_strategies/common.py
+++ b/tap_sybase/sync_strategies/common.py
@@ -110,8 +110,10 @@ def prepare_columns_sql(catalog_entry, c, use_date_data_type_format):
     column_name = """ "{}" """.format(c)
     schema_property = catalog_entry.schema.properties[c]
     sql_data_type = ""
+    # additionalProperties is used with singer.decimal to contain scale/precision
+    # in those cases, there will not be an sql_data_type value in the schema
     if schema_property.additionalProperties:
-        sql_data_type = schema_property.additionalProperties['sql_data_type']
+        sql_data_type = schema_property.additionalProperties.get('sql_data_type',"")
 
     if 'string' in schema_property.type and schema_property.format == 'time':
         return "convert(char, {} , 140)".format(column_name)


### PR DESCRIPTION
- Set scale and precision for float data types
- Replace a dict lookup with a `.get()` defaulting to blank to prevent `KeyError` failures (96e38bc)
- Check for INCREMENTAL load without primary keys removed
  - INCREMENTAL loads can be performed without primary keys as long as there is a replication key