### PR TITLE
Adding dependabot for checking packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file with
+# minimum configuration for two package managers
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "pip"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adding dependabot to tap-sybase to detect libraries which need to be update. Reasons for updates include

- New Features
- Bug Fixes
- Security Fixes

It is a good practice to keep packages up to date.