### PR TITLE
Feature/restrict pymssql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.11
+ * Restricting the upper limit on pymssql to version 2.2.7 for now. There was a breaking change in 2.2.9
+   where the SQL syntax is not compatible with Sybase. Need to investigate and raise a PR with pymssql,
+   for now restrict higher versions of pymssql.
+
 ## 1.0.10
  * Resolving issue with pymssql - excluding version 2.2.8
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "pendulum>=1.2.0",
         "singer-python==5.13.0",
 #        pymssql==2.2.8 broken: https://github.com/pymssql/pymssql/issues/833
-        "pymssql>=2.1.1,!=2.2.8",
+        "pymssql>=2.1.1,<=2.2.7",
         "backoff==1.8.0",
     ],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-sybase",
-    version="1.0.10",
+    version="1.0.11",
     description="Singer.io tap for extracting data from SQL Server - PipelineWise compatible",
     author="Stitch",
     url="https://github.com/s7clarke10/tap-sybase",


### PR DESCRIPTION
 * Restricting the upper limit on pymssql to version 2.2.7 for now. There was a breaking change in 2.2.9
   where the SQL syntax is not compatible with Sybase. Need to investigate and raise a PR with pymssql,
   for now restrict higher versions of pymssql.