### PR TITLE
Support older versions of Sybase via TDS version 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.1.0
+* Downgrading FreeTDS version if connection fails for older versions of Sybase.
 ## 1.0.13
 * Using correct format sybase time datatype
   - https://github.com/s7clarke10/tap-sybase/pull/28

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-sybase",
-    version="1.0.13",
+    version="1.1.0",
     description="Singer.io tap for extracting data from SQL Server - PipelineWise compatible",
     author="Stitch",
     url="https://github.com/s7clarke10/tap-sybase",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "pendulum>=1.2.0",
         "singer-python==5.13.0",
 #        pymssql==2.2.8 broken: https://github.com/pymssql/pymssql/issues/833
-        "pymssql>=2.1.1,<=2.2.7",
+        "pymssql>=2.2.9",
         "backoff==1.8.0",
     ],
     entry_points="""

--- a/tap_sybase/connection.py
+++ b/tap_sybase/connection.py
@@ -47,7 +47,7 @@ class MSSQLConnection(pymssql.Connection):
         except:
             # Set TDS version to lower version supporting older versions of Sybase
             # Older versions of Sybase to not support certain keywords like AS
-            args["tds_version"] = 4.2
+            args["tds_version"] = "4.2"
             conn = pymssql._mssql.connect(**args)
             super().__init__(conn, False, True)
 


### PR DESCRIPTION
**Problem**
Updates to FreeTDS which is used by pymssql has broken access to older versions of Sybase.

Older versions of Sybase do not support the keyword AS.

**Resolution**
Will try to connect with no TDS setting, defaulting to the highest version.

If TDS version 5.0 is not supported, drop back to TDS 4.2. For more details see - https://www.freetds.org/userguide/ChoosingTdsProtocol.html.

