### PR TITLE
Patching tap-sybase with latest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 1.0.12
+* Patching tap-sybase with the latest dependencies
+  - attrs -> ">=24.2.0"
+  - backoff -> ">=1.8.0"
+  - pendulum -> ">=1.2.0"
+  - pymssql -> ">=2.1.4,!=2.2.8"
+  - singer-python -> Replaced with a patched version realit-singer-python = ">=5.0.0"
 
 ## 1.0.11
  * Restricting the upper limit on pymssql to version 2.2.7 for now. There was a breaking change in 2.2.9

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-sybase",
-    version="1.0.11",
+    version="1.0.12",
     description="Singer.io tap for extracting data from SQL Server - PipelineWise compatible",
     author="Stitch",
     url="https://github.com/s7clarke10/tap-sybase",
@@ -14,12 +14,12 @@ setup(
     ],
     py_modules=["tap_sybase"],
     install_requires=[
-        "attrs==23.1.0",
+        "attrs>=24.2.0",
         "pendulum>=1.2.0",
-        "singer-python==5.13.0",
+        "realit-singer-python>=5.0.0",
 #        pymssql==2.2.8 broken: https://github.com/pymssql/pymssql/issues/833
-        "pymssql>=2.1.1,<=2.2.7",
-        "backoff==1.8.0",
+        "pymssql>=2.1.4,!=2.2.8",
+        "backoff>=1.8.0",
     ],
     entry_points="""
           [console_scripts]


### PR DESCRIPTION
Patching dependencies in tap-sybase.

## 1.0.12
* Patching tap-sybase with the latest dependencies
  - attrs -> ">=24.2.0"
  - backoff -> ">=1.8.0"
  - pendulum -> ">=1.2.0"
  - pymssql -> ">=2.1.4,!=2.2.8"
  - singer-python -> Replaced with a patched version realit-singer-python = ">=5.0.0"